### PR TITLE
Support for Bionic and pre-1.0 versions

### DIFF
--- a/.yamllint
+++ b/.yamllint
@@ -1,0 +1,13 @@
+extends: default
+
+rules:
+  braces:
+    max-spaces-inside: 1
+    level: error
+  brackets:
+    max-spaces-inside: 1
+    level: error
+  line-length: disable
+  # NOTE(retr0h): Templates no longer fail this lint rule.
+  #               Uncomment if running old Molecule templates.
+  # truthy: disable

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,6 +1,7 @@
 ---
-### Compliler version to use (some known issues with gcc7)
-gcc_version: gcc-6
+### Set gcc_version if you would like to use a different version than
+### the default (gcc-6)
+#gcc_version: ""
 
 ### Guacamole Settings
 guacamole_version: 0.9.13-incubating
@@ -11,26 +12,6 @@ guacamole_db_name: guacamole_db
 ### Mysql settings (mysql java client)
 mysql_java_client_version: 5.1.44
 
-### Packages to install
-guacamole_apt_install:
-  - tomcat8
-  - libcairo2-dev
-  - libjpeg-turbo8-dev
-  - libpng12-dev
-  - libossp-uuid-dev
-  - libavcodec-dev
-  - libavutil-dev
-  - libswscale-dev
-  - libfreerdp-dev
-  - libpango1.0-dev
-  - libssh2-1-dev
-  - libtelnet-dev
-  - libvncserver-dev
-  - libpulse-dev
-  - libssl-dev
-  - libvorbis-dev
-  - libwebp-dev
-  - "{{ gcc_version }}"
-  - git
-  - mariadb-server
-  - python-mysqldb
+### Set guacamole_apt_install if you would like to use a different version than
+### the default
+#guacamole_apt_install: {}

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,4 +1,7 @@
 ---
+### Compliler version to use (some known issues with gcc7)
+gcc_version: gcc-6
+
 ### Guacamole Settings
 guacamole_version: 0.9.13-incubating
 guacamole_db_user: guacamole
@@ -27,7 +30,7 @@ guacamole_apt_install:
   - libssl-dev
   - libvorbis-dev
   - libwebp-dev
-  - gcc
+  - "{{ gcc_version }}"
   - git
   - mariadb-server
   - python-mysqldb

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -7,6 +7,7 @@ galaxy_info:
     - name: Ubuntu
       versions:
         - xenial
+        - bionic
 
   galaxy_tags:
     - guacamole

--- a/molecule/default/molecule.yml
+++ b/molecule/default/molecule.yml
@@ -1,0 +1,29 @@
+---
+dependency:
+  name: galaxy
+driver:
+  name: docker
+lint:
+  name: yamllint
+  options:
+    config-file: molecule/default/yaml-lint.yml
+platforms:
+  - name: instance
+    image: "geerlingguy/docker-${MOLECULE_DISTRO:-centos7}-ansible:latest"
+    command: ${MOLECULE_DOCKER_COMMAND:-""}
+    volumes:
+      - /sys/fs/cgroup:/sys/fs/cgroup:ro
+    privileged: true
+    pre_build_image: true
+provisioner:
+  name: ansible
+  lint:
+    name: ansible-lint
+  playbooks:
+    converge: ${MOLECULE_PLAYBOOK:-playbook.yml}
+scenario:
+  name: default
+verifier:
+  name: testinfra
+  lint:
+    name: flake8

--- a/molecule/default/playbook.yml
+++ b/molecule/default/playbook.yml
@@ -1,0 +1,24 @@
+---
+- name: Converge
+  hosts: all
+  pre_tasks:
+    - name: Install required packages
+      yum:
+        name: "{{ packages }}"
+        state: present
+        update_cache: true
+      vars:
+        packages:
+          - python-pip
+          - libmariadbclient-dev
+          - python-dev
+  roles:
+    - role: carloslongarela.mariadb
+    - role: alexfeig.guacamole
+  vars:
+#     guacamole_version: 0.9.14
+#     guacamole_db_user: guacamole
+#     guacamole_db_password: guacamole
+#     guacamole_db_name: guacamole
+#     mariadb_root_password: "mariapassword"
+    guacamole_app_name: labs

--- a/molecule/default/requirements.yml
+++ b/molecule/default/requirements.yml
@@ -1,0 +1,2 @@
+---
+- src: carloslongarela.mariadb

--- a/molecule/default/yaml-lint.yml
+++ b/molecule/default/yaml-lint.yml
@@ -1,0 +1,18 @@
+#
+# Copyright (c) 2018 by Delphix. All rights reserved.
+#
+---
+
+extends: default
+
+rules:
+  braces:
+    max-spaces-inside: 1
+    level: error
+  brackets:
+    max-spaces-inside: 1
+    level: error
+  line-length: disable
+  # NOTE(retr0h): Templates no longer fail this lint rule.
+  #               Uncomment if running old Molecule templates.
+  # truthy: disable

--- a/tasks/configure_guacamole.yml
+++ b/tasks/configure_guacamole.yml
@@ -22,18 +22,26 @@
     - localhost
     - 127.0.0.1
   become:  true
+- name: Find schema scripts
+  find:
+    paths: 
+      - /tmp/guacamole-auth-jdbc-{{ guacamole_version }}/mysql
+      - /tmp/guacamole-client-{{ guacamole_version }}/extensions/guacamole-auth-jdbc/modules/guacamole-auth-jdbc-mysql
+    patterns: 'schema'
+    file_type: directory
+  register: schema_dir
 - name: Importing guacamole schema
   mysql_db:
     state: import
     name: "{{ guacamole_db_name }}"
-    target: /tmp/guacamole-auth-jdbc-{{ guacamole_version }}/mysql/schema/001-create-schema.sql
+    target: "{{ schema_dir.files[0].path }}/001-create-schema.sql"
   become: true
-  when: database_status.stdout == ""
+  when: database_status.stdout == "" 
 - name: Importing guacamole user 'guacadmin'
   mysql_db:
     state: import
     name: "{{ guacamole_db_name }}"
-    target: /tmp/guacamole-auth-jdbc-{{ guacamole_version }}/mysql/schema/002-create-admin-user.sql
+    target: "{{ schema_dir.files[0].path }}/002-create-admin-user.sql"
   become: true
   when: database_status.stdout == ""
 - name: Creating guacamole.properties file

--- a/tasks/configure_guacamole.yml
+++ b/tasks/configure_guacamole.yml
@@ -16,8 +16,11 @@
     name: "{{ guacamole_db_user }}"
     password: "{{ guacamole_db_password }}"
     priv: '{{ guacamole_db_name }}.*:SELECT,INSERT,UPDATE,DELETE'
-    host: localhost
+    host: "{{ item }}"
     state: present
+  with_items:
+    - localhost
+    - 127.0.0.1
   become:  true
 - name: Importing guacamole schema
   mysql_db:

--- a/tasks/install_guacamole_client.yml
+++ b/tasks/install_guacamole_client.yml
@@ -8,7 +8,9 @@
   until: task_result is success
   retries: 3
   delay: 2
-  when: "guacamole_version is version('1.0.0', '>=')"
+  when:
+    - guacamole_version != "master"  
+    - "guacamole_version is version('1.0.0', '>=')"
 - name: Retrieving guacamole-{{ guacamole_version }}.war (if < 1.0.0)
   get_url:
     url: "http://archive.apache.org/dist/guacamole/{{ guacamole_version }}/binary/guacamole-{{ guacamole_version }}.war"
@@ -17,4 +19,46 @@
   until: task_result is success
   retries: 3
   delay: 2
-  when: "guacamole_version is version('1.0.0', '<')"
+  when: 
+    - guacamole_version != "master" 
+    - "guacamole_version is version('1.0.0', '<')"
+- name: Retrieving master code base if guacamole_version == master
+  get_url:
+    url: "https://github.com/apache/guacamole-client/archive/master.tar.gz"
+    dest: "/tmp/guacamole-client-{{ guacamole_version }}.tar.gz"
+  register: task_result
+  until: task_result is success
+  retries: 3
+  delay: 2
+  when: guacamole_version == "master"
+- name: Unarchiving guacamole-client-{{ guacamole_version }}.tar.gz
+  unarchive:
+    src: /tmp/guacamole-client-{{ guacamole_version }}.tar.gz
+    dest: /tmp/
+    copy: no
+  when: guacamole_version == "master"
+- name: Build with Maven
+  shell: mvn package
+  args:
+    chdir: /tmp/guacamole-client-{{ guacamole_version }}
+  become: true
+  environment:
+    JAVA_HOME: /usr/lib/jvm/java-8-openjdk-amd64
+  changed_when: false
+  when: guacamole_version == "master"
+- name: Find guacamole.war
+  find:
+    paths: /tmp/guacamole-client-{{ guacamole_version }}/guacamole/target
+    patterns: '*.war'
+  register: guacamole_war
+  when: guacamole_version == "master"
+  tags:
+    - copy
+- name: Copying guacamole.war
+  copy:
+    src: "{{ guacamole_war.files[0].path }}"
+    dest: /var/lib/tomcat8/webapps/{{ guacamole_app_name }}.war
+    remote_src: yes
+  when: guacamole_version == "master"
+  tags:
+    - copy

--- a/tasks/install_guacamole_client.yml
+++ b/tasks/install_guacamole_client.yml
@@ -4,9 +4,17 @@
     url: "http://apache.org/dyn/closer.cgi?action=download&filename=guacamole/{{ guacamole_version }}/binary/guacamole-{{ guacamole_version }}.war"
     dest: "/var/lib/tomcat8/webapps/{{ guacamole_app_name }}.war"
   become: true
+  register: task_result
+  until: task_result is success
+  retries: 3
+  delay: 2
   when: "guacamole_version is version('1.0.0', '>=')"
 - name: Retrieving guacamole-{{ guacamole_version }}.war (if < 1.0.0)
   get_url:
     url: "http://archive.apache.org/dist/guacamole/{{ guacamole_version }}/binary/guacamole-{{ guacamole_version }}.war"
     dest: "/var/lib/tomcat8/webapps/{{ guacamole_app_name }}.war"
+  register: task_result
+  until: task_result is success
+  retries: 3
+  delay: 2
   when: "guacamole_version is version('1.0.0', '<')"

--- a/tasks/install_guacamole_client.yml
+++ b/tasks/install_guacamole_client.yml
@@ -2,11 +2,11 @@
 - name: Retrieving guacamole-{{ guacamole_version }}.war (if >= 1.0.0)
   get_url:
     url: "http://apache.org/dyn/closer.cgi?action=download&filename=guacamole/{{ guacamole_version }}/binary/guacamole-{{ guacamole_version }}.war"
-    dest: /var/lib/tomcat8/webapps/guacamole.war
+    dest: "/var/lib/tomcat8/webapps/{{ guacamole_app_name }}.war"
   become: true
   when: "guacamole_version is version('1.0.0', '>=')"
 - name: Retrieving guacamole-{{ guacamole_version }}.war (if < 1.0.0)
   get_url:
     url: "http://archive.apache.org/dist/guacamole/{{ guacamole_version }}/binary/guacamole-{{ guacamole_version }}.war"
-    dest: /var/lib/tomcat8/webapps/guacamole.war
+    dest: "/var/lib/tomcat8/webapps/{{ guacamole_app_name }}.war"
   when: "guacamole_version is version('1.0.0', '<')"

--- a/tasks/install_guacamole_client.yml
+++ b/tasks/install_guacamole_client.yml
@@ -1,6 +1,12 @@
 ---
-- name: Retrieving guacamole-{{ guacamole_version }}.war
+- name: Retrieving guacamole-{{ guacamole_version }}.war (if >= 1.0.0)
   get_url:
-    url: http://apache.org/dyn/closer.cgi?action=download&filename=guacamole/{{ guacamole_version }}/binary/guacamole-{{ guacamole_version }}.war
+    url: "http://apache.org/dyn/closer.cgi?action=download&filename=guacamole/{{ guacamole_version }}/binary/guacamole-{{ guacamole_version }}.war"
     dest: /var/lib/tomcat8/webapps/guacamole.war
   become: true
+  when: "guacamole_version is version('1.0.0', '>=')"
+- name: Retrieving guacamole-{{ guacamole_version }}.war (if < 1.0.0)
+  get_url:
+    url: "http://archive.apache.org/dist/guacamole/{{ guacamole_version }}/binary/guacamole-{{ guacamole_version }}.war"
+    dest: /var/lib/tomcat8/webapps/guacamole.war
+  when: "guacamole_version is version('1.0.0', '<')"

--- a/tasks/install_guacamole_mysql_authentication.yml
+++ b/tasks/install_guacamole_mysql_authentication.yml
@@ -20,6 +20,10 @@
     url: https://dev.mysql.com/get/Downloads/Connector-J/mysql-connector-java-{{ mysql_java_client_version }}.tar.gz
     dest: /tmp/
   become: true
+  register: task_result
+  until: task_result is success
+  retries: 3
+  delay: 2
 - name: Unarchiving mysql-connector-java-{{ mysql_java_client_version }}.tar.gz
   unarchive:
     src: /tmp/mysql-connector-java-{{ mysql_java_client_version }}.tar.gz
@@ -40,11 +44,19 @@
   get_url:
     url: http://apache.org/dyn/closer.cgi?action=download&filename=guacamole/{{ guacamole_version }}/binary/guacamole-auth-jdbc-{{ guacamole_version }}.tar.gz
     dest: /tmp/
+  register: task_result
+  until: task_result is success
+  retries: 3
+  delay: 2
   when: "guacamole_version is version('1.0.0', '>=')"
 - name: Retrieving guacamole-auth-jdbc-{{ guacamole_version }} (if < 1.0.0)
   get_url:
     url: http://archive.apache.org/dist/guacamole/{{ guacamole_version }}/binary/guacamole-auth-jdbc-{{ guacamole_version }}.tar.gz
     dest: /tmp/
+  register: task_result
+  until: task_result is success
+  retries: 3
+  delay: 2
   when: "guacamole_version is version('1.0.0', '<')"
 - name: Unarchiving guacamole-auth-jdbc-{{ guacamole_version }}
   unarchive:

--- a/tasks/install_guacamole_mysql_authentication.yml
+++ b/tasks/install_guacamole_mysql_authentication.yml
@@ -36,10 +36,16 @@
     dest: /etc/guacamole/lib/
     remote_src: yes
   become: true
-- name: Retrieving guacamole-auth-jdbc-{{ guacamole_version }}
+- name: Retrieving guacamole-auth-jdbc-{{ guacamole_version }} (if >= 1.0.0)
   get_url:
     url: http://apache.org/dyn/closer.cgi?action=download&filename=guacamole/{{ guacamole_version }}/binary/guacamole-auth-jdbc-{{ guacamole_version }}.tar.gz
     dest: /tmp/
+  when: "guacamole_version is version('1.0.0', '>=')"
+- name: Retrieving guacamole-auth-jdbc-{{ guacamole_version }} (if < 1.0.0)
+  get_url:
+    url: http://archive.apache.org/dist/guacamole/{{ guacamole_version }}/binary/guacamole-auth-jdbc-{{ guacamole_version }}.tar.gz
+    dest: /tmp/
+  when: "guacamole_version is version('1.0.0', '<')"
 - name: Unarchiving guacamole-auth-jdbc-{{ guacamole_version }}
   unarchive:
     src: /tmp/guacamole-auth-jdbc-{{ guacamole_version }}.tar.gz

--- a/tasks/install_guacamole_mysql_authentication.yml
+++ b/tasks/install_guacamole_mysql_authentication.yml
@@ -48,7 +48,9 @@
   until: task_result is success
   retries: 3
   delay: 2
-  when: "guacamole_version is version('1.0.0', '>=')"
+  when: 
+    - guacamole_version != "master" 
+    - "guacamole_version is version('1.0.0', '>=')"
 - name: Retrieving guacamole-auth-jdbc-{{ guacamole_version }} (if < 1.0.0)
   get_url:
     url: http://archive.apache.org/dist/guacamole/{{ guacamole_version }}/binary/guacamole-auth-jdbc-{{ guacamole_version }}.tar.gz
@@ -57,15 +59,25 @@
   until: task_result is success
   retries: 3
   delay: 2
-  when: "guacamole_version is version('1.0.0', '<')"
+  when: 
+    - guacamole_version != "master" 
+    - "guacamole_version is version('1.0.0', '<')"
 - name: Unarchiving guacamole-auth-jdbc-{{ guacamole_version }}
   unarchive:
     src: /tmp/guacamole-auth-jdbc-{{ guacamole_version }}.tar.gz
     dest: /tmp/
     copy: no
-- name: Copying guacamole-auth-jdbc-mysql-{{ guacamole_version }}.jar
+  when: guacamole_version != "master"
+- name: Find /guacamole-auth-jdbc-mysql jar
+  find:
+    paths:
+      - /tmp/guacamole-auth-jdbc-{{ guacamole_version }}/mysql
+      - /tmp/guacamole-client-{{ guacamole_version }}/extensions/guacamole-auth-jdbc/modules/guacamole-auth-jdbc-mysql/target/
+    patterns: 'guacamole-auth-jdbc-mysql-*.jar'
+  register: guacamole_jar
+- name: Copying "{{ guacamole_jar.files[0].path }}"
   copy:
-    src: /tmp/guacamole-auth-jdbc-{{ guacamole_version }}/mysql/guacamole-auth-jdbc-mysql-{{ guacamole_version }}.jar
+    src: "{{ guacamole_jar.files[0].path }}"
     dest: /etc/guacamole/extensions/
     remote_src: yes
   become: true

--- a/tasks/install_guacamole_server.yml
+++ b/tasks/install_guacamole_server.yml
@@ -1,8 +1,14 @@
 ---
-- name: Retrieving guacamole-server-{{ guacamole_version }}.tar.gz
+- name: Retrieving guacamole-server-{{ guacamole_version }}.tar.gz (if >= 1.0.0)
   get_url:
-    url: http://apache.org/dyn/closer.cgi?action=download&filename=guacamole/{{ guacamole_version }}/source/guacamole-server-{{ guacamole_version }}.tar.gz
+    url: "http://apache.org/dyn/closer.cgi?action=download&filename=guacamole/{{ guacamole_version }}/source/guacamole-server-{{ guacamole_version }}.tar.gz"
     dest: /tmp/
+  when: "guacamole_version is version('1.0.0', '>=')"
+- name: Retrieving guacamole-server-{{ guacamole_version }}.tar.gz (if < 1.0.0)
+  get_url:
+    url: "http://archive.apache.org/dist/guacamole/{{ guacamole_version }}/source/guacamole-server-{{ guacamole_version }}.tar.gz"
+    dest: /tmp/
+  when: "guacamole_version is version('1.0.0', '<')"
 - name: Unarchiving guacamole-server-{{ guacamole_version }}.tar.gz
   unarchive:
     src: /tmp/guacamole-server-{{ guacamole_version }}.tar.gz

--- a/tasks/install_guacamole_server.yml
+++ b/tasks/install_guacamole_server.yml
@@ -7,7 +7,9 @@
   until: task_result is success
   retries: 3
   delay: 2
-  when: "guacamole_version is version('1.0.0', '>=')"
+  when:
+    - guacamole_version != "master"
+    - "guacamole_version is version('1.0.0', '>=')"
 - name: Retrieving guacamole-server-{{ guacamole_version }}.tar.gz (if < 1.0.0)
   get_url:
     url: "http://archive.apache.org/dist/guacamole/{{ guacamole_version }}/source/guacamole-server-{{ guacamole_version }}.tar.gz"
@@ -16,12 +18,30 @@
   until: task_result is success
   retries: 3
   delay: 2
-  when: "guacamole_version is version('1.0.0', '<')"
+  when:
+    - guacamole_version != "master" 
+    - "guacamole_version is version('1.0.0', '<')"
+- name: Retrieving master code base if guacamole_version == master
+  get_url:
+    url: "https://github.com/apache/guacamole-server/archive/master.tar.gz"
+    dest: "/tmp/guacamole-server-{{ guacamole_version }}.tar.gz"
+  register: task_result
+  until: task_result is success
+  retries: 3
+  delay: 2
+  when: guacamole_version == "master"
 - name: Unarchiving guacamole-server-{{ guacamole_version }}.tar.gz
   unarchive:
     src: /tmp/guacamole-server-{{ guacamole_version }}.tar.gz
     dest: /tmp/
     copy: no
+- name: Running autoreconf -fi if compiling from master
+  shell: autoreconf -fi
+  args:
+    chdir: /tmp/guacamole-server-{{ guacamole_version }}
+  become: true
+  changed_when: false
+  when: guacamole_version == "master"
 - name: Running guacamole configure script
   shell: ./configure --with-init-dir=/etc/init.d
   args:

--- a/tasks/install_guacamole_server.yml
+++ b/tasks/install_guacamole_server.yml
@@ -3,11 +3,19 @@
   get_url:
     url: "http://apache.org/dyn/closer.cgi?action=download&filename=guacamole/{{ guacamole_version }}/source/guacamole-server-{{ guacamole_version }}.tar.gz"
     dest: /tmp/
+  register: task_result
+  until: task_result is success
+  retries: 3
+  delay: 2
   when: "guacamole_version is version('1.0.0', '>=')"
 - name: Retrieving guacamole-server-{{ guacamole_version }}.tar.gz (if < 1.0.0)
   get_url:
     url: "http://archive.apache.org/dist/guacamole/{{ guacamole_version }}/source/guacamole-server-{{ guacamole_version }}.tar.gz"
     dest: /tmp/
+  register: task_result
+  until: task_result is success
+  retries: 3
+  delay: 2
   when: "guacamole_version is version('1.0.0', '<')"
 - name: Unarchiving guacamole-server-{{ guacamole_version }}.tar.gz
   unarchive:

--- a/tasks/install_guacamole_server.yml
+++ b/tasks/install_guacamole_server.yml
@@ -17,6 +17,8 @@
 - name: Making guacamole-server (This will take some time)
   make:
     chdir: /tmp/guacamole-server-{{ guacamole_version }}/
+    params:
+        CC: "{{ gcc_version }}"
   become: true
   changed_when: false
 - name: Make install guacamole-server

--- a/tasks/install_packages.yml
+++ b/tasks/install_packages.yml
@@ -8,6 +8,11 @@
     update_cache: 'yes'
   become: 'true'
   changed_when: false
+- name: Fix for https://github.com/debuerreotype/debuerreotype/issues/10
+  file:
+    path: /usr/share/man/man1
+    state: directory
+    mode: 0755
 - name: Installing required packages
   action: apt pkg="{{ guacamole_apt_install }}" state=present
   become: 'true'

--- a/tasks/install_packages.yml
+++ b/tasks/install_packages.yml
@@ -9,6 +9,5 @@
   become: 'true'
   changed_when: false
 - name: Installing required packages
-  action: apt pkg={{ item }} state=present
-  with_items: "{{ guacamole_apt_install }}"
+  action: apt pkg="{{ guacamole_apt_install }}" state=present
   become: 'true'

--- a/tasks/install_packages.yml
+++ b/tasks/install_packages.yml
@@ -21,6 +21,10 @@
     path: /usr/share/man/man1
     state: directory
     mode: 0755
+- name: Add maven and jdk8 if guacamole_version == master
+  set_fact: 
+    guacamole_apt_install: "{{ guacamole_apt_install + [ 'maven', 'openjdk-8-jdk' ] }}"
+  when: guacamole_version == "master"
 - name: Installing required packages
   action: apt pkg="{{ guacamole_apt_install }}" state=present
   become: 'true'

--- a/tasks/install_packages.yml
+++ b/tasks/install_packages.yml
@@ -3,11 +3,19 @@
   apt:
     name: aptitude
   become: 'true'
+  register: task_result
+  until: task_result is success
+  retries: 3
+  delay: 2
 - name: Updating apt repos
   apt:
     update_cache: 'yes'
   become: 'true'
   changed_when: false
+  register: task_result
+  until: task_result is success
+  retries: 3
+  delay: 2
 - name: Fix for https://github.com/debuerreotype/debuerreotype/issues/10
   file:
     path: /usr/share/man/man1
@@ -16,3 +24,7 @@
 - name: Installing required packages
   action: apt pkg="{{ guacamole_apt_install }}" state=present
   become: 'true'
+  register: task_result
+  until: task_result is success
+  retries: 3
+  delay: 2

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -5,7 +5,7 @@
 - name: Define gcc_version.
   set_fact:
     gcc_version: "{{ __gcc_version}}"
-- name: Define gcc_version.
+- name: Define __guacamole_apt_install.
   set_fact:
     guacamole_apt_install: "{{ __guacamole_apt_install | list }}"
   when: guacamole_apt_install is not defined

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,4 +1,14 @@
 ---
+- name: Include version-specific variables for Ubuntu.
+  include_vars: "{{ ansible_distribution }}-{{ ansible_distribution_major_version }}.yml"
+  when: ansible_distribution == 'Ubuntu'
+- name: Define gcc_version.
+  set_fact:
+    gcc_version: "{{ __gcc_version}}"
+- name: Define gcc_version.
+  set_fact:
+    guacamole_apt_install: "{{ __guacamole_apt_install | list }}"
+  when: guacamole_apt_install is not defined
 - import_tasks: install_packages.yml
 - import_tasks: install_guacamole_server.yml
 - import_tasks: install_guacamole_client.yml

--- a/vars/Ubuntu-16.yml
+++ b/vars/Ubuntu-16.yml
@@ -1,0 +1,27 @@
+---
+### Compliler version to use (some known issues with gcc7)
+__gcc_version: gcc-6
+
+### Packages to install (linpng12-dev was abandoned after 16.04)
+__guacamole_apt_install:
+  - tomcat8
+  - libcairo2-dev
+  - libjpeg-turbo8-dev
+  - libpng12-dev
+  - libossp-uuid-dev
+  - libavcodec-dev
+  - libavutil-dev
+  - libswscale-dev
+  - libfreerdp-dev
+  - libpango1.0-dev
+  - libssh2-1-dev
+  - libtelnet-dev
+  - libvncserver-dev
+  - libpulse-dev
+  - libssl-dev
+  - libvorbis-dev
+  - libwebp-dev
+  - "{{ gcc_version }}"
+  - git
+  - mariadb-server
+  - python-mysqldb

--- a/vars/Ubuntu-18.yml
+++ b/vars/Ubuntu-18.yml
@@ -1,0 +1,27 @@
+---
+### Compliler version to use (some known issues with gcc7)
+__gcc_version: gcc-6
+
+### Packages to install (linpng12-dev was abandoned after 16.04)
+__guacamole_apt_install:
+  - tomcat8
+  - libcairo2-dev
+  - libjpeg-turbo8-dev
+  - libpng-dev
+  - libossp-uuid-dev
+  - libavcodec-dev
+  - libavutil-dev
+  - libswscale-dev
+  - libfreerdp-dev
+  - libpango1.0-dev
+  - libssh2-1-dev
+  - libtelnet-dev
+  - libvncserver-dev
+  - libpulse-dev
+  - libssl-dev
+  - libvorbis-dev
+  - libwebp-dev
+  - "{{ gcc_version }}"
+  - git
+  - mariadb-server
+  - python-mysqldb


### PR DESCRIPTION
1. I updated some deprecated code.
2. Created two vars files for xenial and bionic to account for the different packages
3. The mysql user is created for both localhost & 127.0.0.1 access
4. Added a gcc_version var (gcc-6 by default) to account for [GUACAMOLE-500]
5. Added support for pre-1.0.0 guacamole versions
6. Added fix for issue seen in debuerreotype/debuerreotype#10